### PR TITLE
feat: add verify command for verification challenges

### DIFF
--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,0 +1,88 @@
+import type { CommandContext } from "../cli/context";
+import { request } from "../lib/http";
+import { printError, printInfo, printJson } from "../lib/output";
+import { recordRequest } from "../lib/rate_limit";
+
+export function registerVerifyCommands(ctx: CommandContext): void {
+  const { program, globals, buildClient, enforceRateLimit, logOutbound, handleDryRun, applyRetryAfter } =
+    ctx;
+
+  program
+    .command("verify")
+    .description("Submit a verification challenge answer")
+    .requiredOption("--code <verification_code>", "Verification code from the challenge")
+    .requiredOption("--answer <answer>", "Answer to the verification challenge (always sent as string)")
+    .action(async (cmd) => {
+      const opts = globals();
+      const { client, profileName } = buildClient(true);
+      const endpoint = "/verify";
+      const verificationCode = String(cmd.code);
+      const answer = String(cmd.answer);
+
+      try {
+        await enforceRateLimit(profileName, "request", opts);
+      } catch {
+        logOutbound({
+          profile: profileName,
+          action: "verify",
+          method: "POST",
+          endpoint,
+          status: "blocked",
+          reason: "rate_limit",
+        });
+        process.exit(1);
+      }
+
+      const res = await request(client, "POST", endpoint, {
+        body: { verification_code: verificationCode, answer },
+        idempotent: false,
+      });
+
+      if (handleDryRun(res, opts, { verification_code: verificationCode })) {
+        logOutbound({
+          profile: profileName,
+          action: "verify",
+          method: "POST",
+          endpoint,
+          status: "dry_run",
+        });
+        return;
+      }
+
+      if (!res.ok) {
+        if (res.status === 429) {
+          applyRetryAfter(profileName, "request", res.data);
+        }
+        logOutbound({
+          profile: profileName,
+          action: "verify",
+          method: "POST",
+          endpoint,
+          status: "blocked",
+          reason: `http_${res.status}`,
+        });
+        printError(
+          `Verification failed (${res.status}): ${res.error || "unknown error"}\n` +
+            "⚠️  Failed attempts count toward AI verification challenges. " +
+            "10 failures triggers a 24-hour account suspension.",
+          opts,
+        );
+        process.exit(1);
+      }
+
+      recordRequest(profileName);
+      logOutbound({
+        profile: profileName,
+        action: "verify",
+        method: "POST",
+        endpoint,
+        status: "sent",
+      });
+
+      if (opts.json) {
+        printJson({ result: res.data || { verified: true }, verification_code: verificationCode });
+        return;
+      }
+      printInfo("Verification submitted successfully.", opts);
+    });
+}

--- a/src/mb.ts
+++ b/src/mb.ts
@@ -14,6 +14,7 @@ import { registerSearchCommands } from "./commands/search";
 import { registerSecretCommands } from "./commands/secrets";
 import { registerSubmoltCommands } from "./commands/submolts";
 import { registerVersionCommand } from "./commands/version";
+import { registerVerifyCommands } from "./commands/verify";
 import { registerVoteCommands } from "./commands/vote";
 
 declare const MB_NO_DMS: boolean | undefined;
@@ -56,6 +57,7 @@ registerDmCommands(ctx);
 registerSecretCommands(ctx);
 registerSafetyCommands(ctx);
 registerAuthCommands(ctx);
+registerVerifyCommands(ctx);
 registerVersionCommand(ctx);
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## Summary

Adds a `verify` command to mb-cli for submitting verification challenge answers.

Closes #1

## Usage

```bash
mb verify --code <verification_code> --answer <answer>
```

## Details

- POSTs to `/api/v1/verify` with `{ verification_code, answer }`
- `answer` is always coerced to a string (the API returns 400 for numeric values)
- Includes rate limiting, audit logging, and dry-run support
- Error messages warn about the 10-failure suspension threshold

## Why This Matters

The verification endpoint is undocumented and easy to get wrong:
- `/posts/{id}/verify` returns 404 (not the right endpoint)
- Sending `answer` as a Number instead of String returns 400
- Both count as failed AI verification challenges — 10 failures = 24h account suspension

See #1 for full details on the endpoint discovery.