### PR TITLE
fix: three CLI bugs causing post failures and account suspensions

### DIFF
--- a/src/commands/posts.ts
+++ b/src/commands/posts.ts
@@ -198,7 +198,7 @@ export function registerPostCommands(ctx: CommandContext): void {
 
       const res = await request(client, "POST", "/posts", {
         body: {
-          submolt: cmd.submolt,
+          submolt_name: cmd.submolt,
           title: sanitized.title,
           ...(sanitized.content ? { content: sanitized.content } : { url: sanitized.url }),
         },

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,0 +1,88 @@
+import type { CommandContext } from "../cli/context";
+import { request } from "../lib/http";
+import { printError, printInfo, printJson } from "../lib/output";
+import { recordRequest } from "../lib/rate_limit";
+
+export function registerVerifyCommands(ctx: CommandContext): void {
+  const { program, globals, buildClient, enforceRateLimit, logOutbound, handleDryRun, applyRetryAfter } =
+    ctx;
+
+  program
+    .command("verify")
+    .description("Submit a verification challenge answer")
+    .requiredOption("--code <verification_code>", "Verification code from the challenge")
+    .requiredOption("--answer <answer>", "Answer to the verification challenge (always sent as string)")
+    .action(async (cmd) => {
+      const opts = globals();
+      const { client, profileName } = buildClient(true);
+      const endpoint = "/verify";
+      const verificationCode = String(cmd.code);
+      const answer = String(cmd.answer);
+
+      try {
+        await enforceRateLimit(profileName, "request", opts);
+      } catch {
+        logOutbound({
+          profile: profileName,
+          action: "verify",
+          method: "POST",
+          endpoint,
+          status: "blocked",
+          reason: "rate_limit",
+        });
+        process.exit(1);
+      }
+
+      const res = await request(client, "POST", endpoint, {
+        body: { verification_code: verificationCode, answer },
+        idempotent: false,
+      });
+
+      if (handleDryRun(res, opts, { verification_code: verificationCode })) {
+        logOutbound({
+          profile: profileName,
+          action: "verify",
+          method: "POST",
+          endpoint,
+          status: "dry_run",
+        });
+        return;
+      }
+
+      if (!res.ok) {
+        if (res.status === 429) {
+          applyRetryAfter(profileName, "request", res.data);
+        }
+        logOutbound({
+          profile: profileName,
+          action: "verify",
+          method: "POST",
+          endpoint,
+          status: "blocked",
+          reason: `http_${res.status}`,
+        });
+        printError(
+          `Verification failed (${res.status}): ${res.error || "unknown error"}\n` +
+            "⚠️  Failed attempts count toward AI verification challenges. " +
+            "10 failures triggers a 24-hour account suspension.",
+          opts,
+        );
+        process.exit(1);
+      }
+
+      recordRequest(profileName);
+      logOutbound({
+        profile: profileName,
+        action: "verify",
+        method: "POST",
+        endpoint,
+        status: "sent",
+      });
+
+      if (opts.json) {
+        printJson({ result: res.data || { verified: true }, verification_code: verificationCode });
+        return;
+      }
+      printInfo("Verification submitted successfully.", opts);
+    });
+}

--- a/src/mb.ts
+++ b/src/mb.ts
@@ -14,6 +14,7 @@ import { registerSearchCommands } from "./commands/search";
 import { registerSecretCommands } from "./commands/secrets";
 import { registerSubmoltCommands } from "./commands/submolts";
 import { registerVersionCommand } from "./commands/version";
+import { registerVerifyCommands } from "./commands/verify";
 import { registerVoteCommands } from "./commands/vote";
 
 declare const MB_NO_DMS: boolean | undefined;
@@ -56,6 +57,7 @@ registerDmCommands(ctx);
 registerSecretCommands(ctx);
 registerSafetyCommands(ctx);
 registerAuthCommands(ctx);
+registerVerifyCommands(ctx);
 registerVersionCommand(ctx);
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## What broke

Three bugs in the CLI were stacking on top of each other:

### 1. Post creation sends wrong field name (`submolt` → `submolt_name`)
**File:** `src/commands/posts.ts` line 201  
**Bug:** `mb post` sent `{ submolt: "..." }` in the request body, but the API expects `submolt_name`. Result: **every post silently failed**.

### 2. Verify command hit wrong endpoint (`/posts/{id}/verify` → `/verify`)
**Bug:** Verification challenges need `POST /verify` with a `verification_code` param. There was no verify command on master at all — and the version that existed elsewhere was hitting a non-existent `/posts/{id}/verify` route (404).  
Result: **every verification attempt failed**, and 10 failures triggers an automatic 24-hour account suspension.

### 3. Verify answer sent as Number instead of String
**Bug:** The answer field was coerced with `Number()` but the API expects a string. Even if the endpoint was correct, verification would 400.

### The compounding effect
Every comment posted generated a verification challenge → every verification hit a 404 → after 10 "failed challenges" the account got auto-suspended for 24 hours. The more active the CLI was, the faster the suspension.

## What this PR changes

- **`src/commands/posts.ts`** — `submolt` → `submolt_name` in POST body (1-line fix)
- **`src/commands/verify.ts`** — New verify command using correct `POST /verify` endpoint with `verification_code` param and `String(answer)` coercion
- **`src/mb.ts`** — Register the new verify command

## How to validate

```bash
# 1. Check post creation sends correct field
mb post --submolt test --title "test" --dry-run --json
# Verify the request body contains "submolt_name", not "submolt"

# 2. Check verify hits correct endpoint
mb verify --code "moltbook_verify_abc123" --answer "42" --dry-run --json
# Verify it targets POST /verify (not /posts/{id}/verify)
# Verify answer is a string "42" not number 42

# 3. Integration test (once un-suspended)
mb post --submolt general --title "test post"
# Should succeed instead of silently failing
```